### PR TITLE
Optimize Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM python:3.13-slim
-LABEL org.opencontainers.image.source="https://github.com/jhjcpishva/webhook-to-nats"
+# Use a builder stage to install dependencies with uv
+FROM python:3.13-alpine AS builder
 
-# Install uv.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# install uv for the build only
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-# Copy the application into the container.
+WORKDIR /app
+# copy project metadata for dependency installation
+COPY pyproject.toml uv.lock ./
+
+# install dependencies into the system location
+RUN uv pip install --system --no-cache --requirements uv.lock
+
+# final runtime image
+FROM python:3.13-alpine
+WORKDIR /app
+
+# copy installed dependencies, excluding the uv binary
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+
+# copy application code
 COPY . /app
 
-# Install the application dependencies.
-WORKDIR /app
-RUN uv sync --frozen --no-cache
-
-# Run the application.
-CMD ["uv", "run", "main.py"]
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- switch to a multistage Docker build
- use `uv` only during the build stage
- run the app with `python` instead of `uv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685277417260832ea2a6f03a17afdab2