### PR TITLE
Switch to ci-workflows reusable workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build & Push Docker Image
 
 on:
   push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,55 +12,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    outputs:
-      image_name: ${{ steps.set-image-name.outputs.image_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Set image name
-        id: set-image-name
-        run: |
-          echo "image_name=ghcr.io/$(echo '${{ github.repository }}' | \
-          tr '[:upper:]' '[:lower:]')" | \
-          tee -a $GITHUB_OUTPUT >> $GITHUB_ENV
-
-      - name: Build Docker image (without push)
-        run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.image_name }}:latest .
-
-  push:
-    needs: build
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Use build output image name
-        run: echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
-
-      - name: Push Docker image
-        run: |
-          TAG=latest
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
-          fi
-          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.IMAGE_NAME }}:$TAG --push .
+  docker-build:
+    uses: jhjcpishva/ci-workflows/.github/workflows/docker-build.yml@main
+    with:
+      platforms: linux/amd64,linux/arm64
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
## Summary
- simplify CI and call `ci-workflows` reusable workflow for docker builds

## Testing
- `python -m py_compile main.py config.py nats_client.py Webhook/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551b32dee8832e8fdbdf6745cf5d15